### PR TITLE
Fix missing separator error

### DIFF
--- a/config
+++ b/config
@@ -6,9 +6,7 @@ ngx_addon_name=ngx_http_graphite_module
 if test -n "$ngx_module_link"; then
     ngx_module_type=HTTP
     ngx_module_name=ngx_http_graphite_module
-    ngx_module_incs="
-        $ngx_addon_dir/src\
-    "
+    ngx_module_incs="$ngx_addon_dir/src"
     ngx_module_srcs="\
         $ngx_addon_dir/src/ngx_http_graphite_allocator.c\
         $ngx_addon_dir/src/ngx_http_graphite_array.c\
@@ -17,9 +15,7 @@ if test -n "$ngx_module_link"; then
     . auto/module
 else
     HTTP_MODULES="$HTTP_MODULES ngx_http_graphite_module"
-    HTTP_INCS="$HTTP_INCS \
-        $ngx_addon_dir/src\
-    "
+    HTTP_INCS="$HTTP_INCS $ngx_addon_dir/src"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
         $ngx_addon_dir/src/ngx_http_graphite_allocator.c \
         $ngx_addon_dir/src/ngx_http_graphite_array.c \


### PR DESCRIPTION
Fixes `*** missing separator (did you mean TAB instead of 8 spaces?).  Stop.`