### PR TITLE
Add feature: if location name renders empty, set it to "_"

### DIFF
--- a/src/ngx_http_graphite_module.c
+++ b/src/ngx_http_graphite_module.c
@@ -667,6 +667,10 @@ ngx_http_graphite_location(ngx_pool_t *pool, const ngx_str_t *uri) {
     while (split->len > 0 && split->data[split->len - 1] == '_')
         split->len--;
 
+    if (split->len == 0) {
+        split->data[split->len++] = '_';
+    }
+
     return split;
 }
 


### PR DESCRIPTION
If location is "/" or it's name has all non-alphanumeric symbols,
module changes it into "\_" symbols and strips them all and name becomes an empty string.
Thus module doesn't send any data to graphite.
For such corner case we set name to "\_".