### PR TITLE
RB-27104: do not group error_log files by their directories

### DIFF
--- a/src/ngx_http_graphite_module.c
+++ b/src/ngx_http_graphite_module.c
@@ -534,7 +534,7 @@ ngx_http_graphite_init_error_log(ngx_conf_t *cf) {
 
             if (isalnum(c))
                 continue;
-            log_name.data[i] = (ngx_path_separator(c) ? '.' : '_');
+            log_name.data[i] = '_';
         }
 
         ngx_http_graphite_log_t *gl;


### PR DESCRIPTION
In 0c9abce3 ("RB-27104: group error_log files by their directories") we
added added the grouping. But admins do not like the feature. So, now
'/' is replaced with '_' as the other non-alphanums.

Note that the other features of 0c9abce3 (replacing relative paths with
absolute ones and removing duplicate '/') are still present.

/usr/local/var/log/error.log is now converted to
usr_local_var_log_error_log graph.