### PR TITLE
cannot close connection when it was never opened

### DIFF
--- a/src/ngx_http_graphite_net.c
+++ b/src/ngx_http_graphite_net.c
@@ -57,7 +57,8 @@ ngx_http_graphite_net_send_udp(ngx_http_graphite_main_conf_t *gmcf, ngx_log_t *l
 
     if (ngx_http_graphite_net_connect_udp(gmcf, log) != NGX_OK) {
         ngx_log_error(NGX_LOG_ERR, log, 0, "graphite connect to %V failed", &gmcf->server.name);
-        goto failed;
+        gmcf->connection = NULL;
+        return NGX_ERROR;
     }
 
     gmcf->connection->data = gmcf;


### PR DESCRIPTION
We have seen some nginx coredumps in connection overload situations lately.
We don't want to be in connection overload of course, but we looked at the core dump
and found it was caused by the graphite module - when it can't open a connection it
jumps to "failed" label where it tries to close the connection and promptly crashes
following a null pointer.
This is a possible fix; another possible fix would be to add
`if (gmcf->connection != NULL)`
in the "failed:" section around `ngx_close_connection()`.