### PR TITLE
add support of nginx >= 1.21.5

### DIFF
--- a/src/ngx_http_graphite_module.c
+++ b/src/ngx_http_graphite_module.c
@@ -2020,7 +2020,7 @@ ngx_http_graphite_get_source(ngx_http_graphite_context_t *context, const ngx_str
                 return NGX_ERROR;
             }
 
-            if (ngx_regex_exec(rc.regex, name, NULL, 0) >= 0)
+            if (ngx_regex_exec(rc.regex, (ngx_str_t*)name, NULL, 0) >= 0)
                 break;
         }
     }


### PR DESCRIPTION
ngx_http_graphite_get_source():
Starting nginx v1.21.5 ngx_regex_exec() is a function, not a macro.
The function accepts (ngx_str_t*) as the second parameter, not
(const ngx_str_t*). But actually the function doesn't modify the
structure, so we can safely cast a pointer.

Fixes #47