### PR TITLE
skip -1 values for upstream connect and header time

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,9 +283,15 @@ ssl\_handshake\_time    | ms    | avg  | time spent on ssl handsake
 ssl\_cache\_usage       | %     | last | how much SSL cache used
 content\_time           | ms    | avg  | time spent generating content inside nginx
 gzip\_time              | ms    | avg  | time spent gzipping content ob-the-fly
+lua\_time               | ms    | avg  | time spent on lua code
 upstream\_time          | ms    | avg  | time spent tailking with upstream
 upstream\_connect\_time | ms    | avg  | time spent on upstream connect (nginx >= 1.9.1)
 upstream\_header\_time  | ms    | avg  | time spent on upstream header (nginx >= 1.9.1)
+upstream\_response\_2xx\_rps      | rps   | sum  | total upstream responses number with 2xx code (nginx >= 1.9.1)
+upstream\_response\_3xx\_rps      | rps   | sum  | total upstream responses number with 3xx code (nginx >= 1.9.1)
+upstream\_response\_4xx\_rps      | rps   | sum  | total upstream responses number with 4xx code (nginx >= 1.9.1)
+upstream\_response\_5xx\_rps      | rps   | sum  | total upstream responses number with 5xx code (nginx >= 1.9.1)
+upstream\_response\_[0-9]{3}\_rps | rps   | sum  | total upstream responses number with given code (nginx >= 1.9.1)
 rps                     | rps   | sum  | total requests number per second
 keepalive\_rps          | rps   | sum  | requests number sent over previously opened keepalive connection
 response\_2xx\_rps      | rps   | sum  | total responses number with 2xx code
@@ -294,7 +300,6 @@ response\_4xx\_rps      | rps   | sum  | total responses number with 4xx code
 response\_5xx\_rps      | rps   | sum  | total responses number with 5xx code
 response\_[0-9]{3}\_rps | rps   | sum  | total responses number with given code
 upstream\_cache\_(miss\|bypass\|expired\|stale\|updating\|revalidated\|hit)\_rps | rps   | sum  | totar responses with a given upstream cache status
-lua\_time               | ms    | avg  | time spent on lua code
 
 Percentiles
 ===========

--- a/src/ngx_http_graphite_module.c
+++ b/src/ngx_http_graphite_module.c
@@ -3526,7 +3526,7 @@ ngx_http_graphite_source_upstream_connect_time(const ngx_http_graphite_source_t 
     state = r->upstream_states->elts;
 
     for (i = 0 ; i < r->upstream_states->nelts; i++) {
-        if (state[i].status)
+        if (state[i].status && state[i].connect_time != (ngx_msec_t)-1)
             ms += (ngx_msec_int_t)(state[i].connect_time);
     }
     ms = ngx_max(ms, 0);
@@ -3553,7 +3553,7 @@ ngx_http_graphite_source_upstream_header_time(const ngx_http_graphite_source_t *
     state = r->upstream_states->elts;
 
     for (i = 0 ; i < r->upstream_states->nelts; i++) {
-        if (state[i].status)
+        if (state[i].status && state[i].header_time != (ngx_msec_t)-1)
             ms += (ngx_msec_int_t)(state[i].header_time);
     }
     ms = ngx_max(ms, 0);

--- a/src/ngx_http_graphite_module.c
+++ b/src/ngx_http_graphite_module.c
@@ -170,7 +170,7 @@ typedef struct ngx_http_graphite_arg_s {
 #ifdef NGX_GRAPHITE_PATCH
 #define DEFAULT_PARAMS "request_time|bytes_sent|body_bytes_sent|request_length|ssl_handshake_time|ssl_cache_usage|content_time|gzip_time|upstream_time|upstream_connect_time|upstream_header_time|rps|keepalive_rps|response_2xx_rps|response_3xx_rps|response_4xx_rps|response_5xx_rps"
 #else
-#define DEFAULT_PARAMS "request_time|bytes_sent|body_bytes_sent|request_length|ssl_cache_usage|rps|keepalive_rps|response_2xx_rps|response_3xx_rps|response_4xx_rps|response_5xx_rps"
+#define DEFAULT_PARAMS "request_time|bytes_sent|body_bytes_sent|request_length|ssl_cache_usage|upstream_time|upstream_connect_time|upstream_header_time|rps|keepalive_rps|response_2xx_rps|response_3xx_rps|response_4xx_rps|response_5xx_rps"
 #endif
 
 #define CONFIG_ARGS_COUNT (sizeof(ngx_http_graphite_config_args) / sizeof(ngx_http_graphite_config_args[0]))
@@ -274,13 +274,13 @@ static double ngx_http_graphite_source_response_4xx_rps(const ngx_http_graphite_
 static double ngx_http_graphite_source_response_5xx_rps(const ngx_http_graphite_source_t *source, ngx_http_request_t *r);
 static double ngx_http_graphite_source_response_xxx_rps(const ngx_http_graphite_source_t *source, ngx_http_request_t *r);
 static double ngx_http_graphite_source_upstream_cache_status_rps(const ngx_http_graphite_source_t *source, ngx_http_request_t *r);
+static double ngx_http_graphite_source_upstream_time(const ngx_http_graphite_source_t *source, ngx_http_request_t *r);
+static double ngx_http_graphite_source_upstream_connect_time(const ngx_http_graphite_source_t *source, ngx_http_request_t *r);
+static double ngx_http_graphite_source_upstream_header_time(const ngx_http_graphite_source_t *source, ngx_http_request_t *r);
 #ifdef NGX_GRAPHITE_PATCH
 static double ngx_http_graphite_source_ssl_handshake_time(const ngx_http_graphite_source_t *source, ngx_http_request_t *r);
 static double ngx_http_graphite_source_content_time(const ngx_http_graphite_source_t *source, ngx_http_request_t *r);
 static double ngx_http_graphite_source_gzip_time(const ngx_http_graphite_source_t *source, ngx_http_request_t *r);
-static double ngx_http_graphite_source_upstream_time(const ngx_http_graphite_source_t *source, ngx_http_request_t *r);
-static double ngx_http_graphite_source_upstream_connect_time(const ngx_http_graphite_source_t *source, ngx_http_request_t *r);
-static double ngx_http_graphite_source_upstream_header_time(const ngx_http_graphite_source_t *source, ngx_http_request_t *r);
 static double ngx_http_graphite_source_lua_time(const ngx_http_graphite_source_t *source, ngx_http_request_t *r);
 #endif
 
@@ -298,13 +298,13 @@ static const ngx_http_graphite_source_t ngx_http_graphite_sources[] = {
     { .name = ngx_string("response_5xx_rps"), .get = ngx_http_graphite_source_response_5xx_rps, .aggregate = ngx_http_graphite_aggregate_persec },
     { .name = ngx_string("response_\\d\\d\\d_rps"), .re = 1, .get = ngx_http_graphite_source_response_xxx_rps, .aggregate = ngx_http_graphite_aggregate_persec },
     { .name = ngx_string("upstream_cache_(miss|bypass|expired|stale|updating|revalidated|hit)_rps"), .re = 1, .get = ngx_http_graphite_source_upstream_cache_status_rps, .aggregate = ngx_http_graphite_aggregate_persec },
+    { .name = ngx_string("upstream_time"), .get = ngx_http_graphite_source_upstream_time, .aggregate = ngx_http_graphite_aggregate_avg },
+    { .name = ngx_string("upstream_connect_time"), .get = ngx_http_graphite_source_upstream_connect_time, .aggregate = ngx_http_graphite_aggregate_avg },
+    { .name = ngx_string("upstream_header_time"), .get = ngx_http_graphite_source_upstream_header_time, .aggregate = ngx_http_graphite_aggregate_avg },
 #ifdef NGX_GRAPHITE_PATCH
     { .name = ngx_string("ssl_handshake_time"), .get = ngx_http_graphite_source_ssl_handshake_time, .aggregate = ngx_http_graphite_aggregate_avg },
     { .name = ngx_string("content_time"), .get = ngx_http_graphite_source_content_time, .aggregate = ngx_http_graphite_aggregate_avg },
     { .name = ngx_string("gzip_time"), .get = ngx_http_graphite_source_gzip_time, .aggregate = ngx_http_graphite_aggregate_avg },
-    { .name = ngx_string("upstream_time"), .get = ngx_http_graphite_source_upstream_time, .aggregate = ngx_http_graphite_aggregate_avg },
-    { .name = ngx_string("upstream_connect_time"), .get = ngx_http_graphite_source_upstream_connect_time, .aggregate = ngx_http_graphite_aggregate_avg },
-    { .name = ngx_string("upstream_header_time"), .get = ngx_http_graphite_source_upstream_header_time, .aggregate = ngx_http_graphite_aggregate_avg },
     { .name = ngx_string("lua_time"), .get = ngx_http_graphite_source_lua_time, .aggregate = ngx_http_graphite_aggregate_avg },
 #endif
 };
@@ -3485,6 +3485,14 @@ ngx_http_graphite_source_gzip_time(const ngx_http_graphite_source_t *source, ngx
 }
 
 static double
+ngx_http_graphite_source_lua_time(const ngx_http_graphite_source_t *source, ngx_http_request_t *r) {
+
+    return r->lua_time;
+}
+
+#endif /*NGX_GRAPHITE_PATCH*/
+
+static double
 ngx_http_graphite_source_upstream_time(const ngx_http_graphite_source_t *source, ngx_http_request_t *r) {
 
     ngx_uint_t i;
@@ -3563,14 +3571,6 @@ ngx_http_graphite_source_upstream_header_time(const ngx_http_graphite_source_t *
     return 0
 #endif
 }
-
-static double
-ngx_http_graphite_source_lua_time(const ngx_http_graphite_source_t *source, ngx_http_request_t *r) {
-
-    return r->lua_time;
-}
-
-#endif
 
 static double
 ngx_http_graphite_aggregate_avg(const ngx_http_graphite_interval_t *interval, const void *data) {


### PR DESCRIPTION
If we accessed several upstreams and some of them were unsuccessful, the values of connect_time, header_time in such upstreams may remain equal to the initialization value -1,
although the status of such upstreams may be non-zero. As a result, the values of upstream connect and header time in statistics may be less than the real values.

To fix this problem -1 values of connect and header time are skipped.