### PR TITLE
Fix buffer overflow in uri parsing

### DIFF
--- a/src/ngx_http_graphite_module.c
+++ b/src/ngx_http_graphite_module.c
@@ -835,17 +835,13 @@ ngx_http_graphite_location(ngx_pool_t *pool, const ngx_str_t *uri) {
             split->data[split->len++] = '_';
     }
 
-    while (split->len > 0 && split->data[0] == '_') {
+    while (split->len > 1 && split->data[0] == '_') {
         split->data++;
         split->len--;
     }
 
-    while (split->len > 0 && split->data[split->len - 1] == '_')
+    while (split->len > 1 && split->data[split->len - 1] == '_')
         split->len--;
-
-    if (split->len == 0) {
-        split->data[split->len++] = '_';
-    }
 
     return split;
 }


### PR DESCRIPTION
Resolved a buffer overflow bug in ngx_http_graphite_location() when parsing uri entirely made up of underscores. The loop incorrectly traverses past the buffer's boundary:

while (split->len > 0 && split->data[0] == '_') {
    split->data++;
    split->len--;
}

Later, it writes a '_' character outside of the buffer:

if (split->len == 0) {
    split->data[split->len++] = '_';
}

This problem occurs with the uri: "/".